### PR TITLE
Document experimental x-behaviorPolicies extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Build and run:
 
 ```bash
 cargo run -- validate examples/log-processor.passport.yaml
+cargo run -- validate examples/specauthor-behavior-policy.passport.yaml
 ```
 
 Install locally:
@@ -45,6 +46,12 @@ The validator checks:
 - signature field presence and base64 syntax
 - optional SHA-256/SHA-512 file integrity checks via
   `agentIntegrity.codeHashes`
+
+The v1alpha1 validator is intentionally forward-compatible: unknown fields are
+ignored by the core validator. Experimental `x-*` fields such as
+`x-behaviorPolicies` may be used for semantic or LLM behavior declarations, but
+they are report-only extension data unless a consuming system explicitly
+implements their meaning. They are not runtime security enforcement by default.
 
 Full cryptographic signature verification is intentionally not implemented yet:
 the RFC still needs a canonicalization profile and trust-store model so that

--- a/drafts/agent-passport.md
+++ b/drafts/agent-passport.md
@@ -640,7 +640,7 @@ To ensure forward compatibility and flexibility, the Agent Passport specificatio
 
   * **Addition of New Fields:** New fields CAN be added to existing objects within the Agent Passport schema. Implementations MUST be designed to gracefully ignore any unknown fields they encounter.
   * **Addition of New Top-Level Sections:** Entirely new top-level sections CAN be introduced.
-  * **x- Prefixes for Experimental Fields (Proposed):** For experimental or vendor-specific fields, a convention of using an `x-` prefix (e.g., `x-custom-field`) is proposed.
+  * **x- Prefixes for Experimental Fields:** For experimental or vendor-specific fields, a convention of using an `x-` prefix (e.g., `x-custom-field`) is supported. A field such as `x-behaviorPolicies` MAY declare semantic or LLM behavior constraints for a consuming system, but such extensions are report-only unless that consumer defines explicit enforcement semantics. They MUST NOT be treated as core runtime security enforcement by default.
 
 ### 8.2. Versioning Strategy
 

--- a/examples/specauthor-behavior-policy.passport.yaml
+++ b/examples/specauthor-behavior-policy.passport.yaml
@@ -1,0 +1,68 @@
+passport:
+  apiVersion: "agent-passport.io/v1alpha1"
+  kind: "AgentPassport"
+  metadata:
+    name: "specauthor-agent"
+    uid: "6a8a0fef-7e6f-4fc9-8847-4f42b5d78146"
+    version: "0.1.0"
+    issueDate: "2026-01-01T00:00:00Z"
+    expiryDate: "9999-12-31T23:59:59Z"
+    issuer: "0AL Internal Draft Authority"
+  spec:
+    entity:
+      type: "LLM-agent"
+      description: "Produces review-only specification drafts under semantic authoring constraints."
+      owner: "0AL SpecGraph"
+      contact: "https://github.com/0al-spec/SpecGraph"
+    capabilities:
+      - name: "compose_specification"
+        description: "Creates review-only generated specification artifacts."
+        signature:
+          parameters:
+            - name: "operator_intent"
+              type: "string"
+              required: true
+            - name: "active_context"
+              type: "object"
+              required: true
+          returns:
+            type: "object"
+            description: "Review-only generated specification artifact."
+        accessControl:
+          - "specgraph-operators"
+    resources:
+      cpu: "1000m"
+      memory: "2Gi"
+      fileSystemAccess:
+        - path: "/workspace/specgraph"
+          permissions:
+            - "read"
+            - "write"
+    securityPolicies:
+      capabilities: []
+      networkRestrictions:
+        denyList:
+          - "0.0.0.0/0"
+      executionEnvironment:
+        isolated: true
+        privileged: false
+  x-behaviorPolicies:
+    - id: "specgraph.specauthor.behavior-policy.v0.1"
+      status: "experimental"
+      appliesTo:
+        - "compose_specification"
+      reportOnly: true
+      runtimeEnforcement: false
+      requires:
+        ontologyResolution: true
+        contextResolution: true
+        claimCalibration: "FGR"
+      rejectsOutputWhen:
+        - "missing_active_frame"
+        - "strong_claim_without_fgr"
+        - "low_reliability_decision"
+  signature:
+    algorithm: "EdDSA"
+    value: "ZHJhZnQtc2lnbmF0dXJl"
+    publicKeyRef: "did:example:0al:specauthor-agent:key1"
+    signedBy: "0ALInternalDraftSigner"

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1123,6 +1123,35 @@ mod tests {
         }));
     }
 
+    #[test]
+    fn accepts_experimental_x_behavior_policies_extension() {
+        let source = valid_passport().replace(
+            r#"  signature:
+    algorithm: "EdDSA""#,
+            r#"  x-behaviorPolicies:
+    - id: "specgraph.specauthor.behavior-policy.v0.1"
+      status: "experimental"
+      appliesTo:
+        - "process_logs"
+      reportOnly: true
+      runtimeEnforcement: false
+      requires:
+        contextResolution: true
+      rejectsOutputWhen:
+        - "missing_active_context"
+  signature:
+    algorithm: "EdDSA""#,
+        );
+
+        let report = validate_str(&source, &CheckOptions::default());
+
+        assert!(
+            report.valid,
+            "expected x-behaviorPolicies extension to remain report-only/ignored, got: {:?}",
+            report.checks
+        );
+    }
+
     fn valid_passport() -> &'static str {
         r#"passport:
   apiVersion: "agent-passport.io/v1alpha1"


### PR DESCRIPTION
## Motivation

SpecGraph now has a local report-only `x-behaviorPolicies` experiment for SpecAuthorAgent. Agent Passport should document that `x-*` behavior policy extensions are valid extension data while keeping them outside the core runtime enforcement schema.

## Goals

- Show a valid passport example with `x-behaviorPolicies`.
- Add validator regression coverage that unknown `x-*` extension data is accepted.
- Clarify docs/draft language that semantic or LLM behavior declarations are report-only unless a consumer explicitly implements their meaning.

## Changes

- Added `examples/specauthor-behavior-policy.passport.yaml`.
- Added a validator unit test for `x-behaviorPolicies`.
- Updated README validator notes.
- Clarified draft extensibility text for `x-*` fields.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo run -- validate examples/specauthor-behavior-policy.passport.yaml`
- `cargo clippy --all-targets -- -D warnings`

## Boundaries and Non-Goals

- Does not add `x-behaviorPolicies` to the core typed schema.
- Does not make behavior policies mandatory.
- Does not define runtime security enforcement semantics for behavior policies.

## Notes

- This is intentionally compatible with the existing forward-compatible validator behavior: unknown fields remain ignored by the core validator.
